### PR TITLE
Response parsing

### DIFF
--- a/dictionary_client/dictionary_client.py
+++ b/dictionary_client/dictionary_client.py
@@ -80,7 +80,7 @@ class DictionaryClient:
         return int(response_bytes[:3])
 
     def _response_complete(self, response_bytes):
-        return b"250" in response_bytes
+        return b"250" in response_bytes and response_bytes[-2:] == b"\r\n"
 
     def _get_strategies(self):
         self.sock.sendall(show_strategies_command())

--- a/dictionary_client/response.py
+++ b/dictionary_client/response.py
@@ -108,16 +108,24 @@ class DatabaseInfoResponse(MultiLineResponse):
 class HandshakeResponse(PreliminaryResponse):
     CAPABILITIES_RE = re.compile(r"<([\w\d_]*(\.[\w\d_]+)*)>")
     MSG_ID_RE = re.compile(r"(<[\d\w@.]+>)\r\n")
+    BANNER_RE = re.compile(r"^220 ([^<]+)?")
 
     def parse_content(self):
         capabilities_match = self.CAPABILITIES_RE.search(self.response_text)
         msg_id_match = self.MSG_ID_RE.search(self.response_text)
+        banner_match = self.BANNER_RE.search(self.response_text)
         if not msg_id_match:
             raise ValueError(
                 "Client got unexpected banner in connection response: "
                 f"{self.response_text}"
             )
-        content = {"message_id": msg_id_match.group(1), "capabilities": None}
+        content = {
+            "message_id": msg_id_match.group(1),
+            "capabilities": None,
+            "banner": None,
+        }
         if capabilities_match:
             content.update({"capabilities": capabilities_match.group(1).split(".")})
+        if banner_match:
+            content.update({"banner": banner_match.group(1).rstrip()})
         return content

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
-from setuptools import setup, find_packages
 from os import path
+from setuptools import setup
 
 here = path.abspath(path.dirname(__file__))
 


### PR DESCRIPTION
Fixes #1 

The termination condition for the socket read loop in `_recv_all` was too broad. Simple fix is to check for the presence of the 250 code and a terminating `\r\n`. We'll see how it fares in the wild.

Added the optional server banner text to the `server_info` structure.