### PR TITLE
Cover illegal param case for match.

### DIFF
--- a/dictionary_client/response.py
+++ b/dictionary_client/response.py
@@ -79,7 +79,7 @@ class DefineWordResponse(BaseResponse):
 
 class MatchResponse(BaseResponse):
     def parse_content(self):
-        if self.status_code == DictStatusCode.NO_MATCH:
+        if self.status_code in [DictStatusCode.NO_MATCH, DictStatusCode.ILLEGAL_PARAMS]:
             return None
         match_lines = self.get_multipart_content_lines()
         match_lines = match_lines[: match_lines.index(self.CONTENT_DELIMITER)]

--- a/dictionary_client/response.py
+++ b/dictionary_client/response.py
@@ -79,10 +79,13 @@ class DefineWordResponse(BaseResponse):
 
 class MatchResponse(BaseResponse):
     def parse_content(self):
-        if self.status_code in [DictStatusCode.NO_MATCH, DictStatusCode.ILLEGAL_PARAMS]:
+        if self.status_code == DictStatusCode.NO_MATCH:
             return None
         match_lines = self.get_multipart_content_lines()
-        match_lines = match_lines[: match_lines.index(self.CONTENT_DELIMITER)]
+        try:
+            match_lines = match_lines[: match_lines.index(self.CONTENT_DELIMITER)]
+        except ValueError:
+            return None
         matches = defaultdict(list)
         for line in match_lines:
             db_name, match = line.split(maxsplit=1)
@@ -106,10 +109,7 @@ class DatabaseInfoResponse(MultiLineResponse):
 
 class HandshakeResponse(PreliminaryResponse):
     MSG_ATOM = r"[^\s<>.\\]"
-    CAPABILITIES_RE = re.compile(
-        fr"< ( {MSG_ATOM}* (\.{MSG_ATOM}+)* ) >",
-        re.VERBOSE,
-    )
+    CAPABILITIES_RE = re.compile(fr"< ( {MSG_ATOM}* (\.{MSG_ATOM}+)* ) >", re.VERBOSE,)
     MSG_ID_RE = re.compile(
         fr"""
         (<


### PR DESCRIPTION
Hey,

Thanks for this great library! This is a mini fix to correctly return `None` for illegal param return codes in `match` commands.