### PR TITLE
fix premature read termination on 250

### DIFF
--- a/dictionary_client/dictionary_client.py
+++ b/dictionary_client/dictionary_client.py
@@ -116,7 +116,7 @@ class DictionaryClient:
         return int(response_bytes[:3])
 
     def _response_complete(self, response_bytes):
-        return b"250" in response_bytes and response_bytes[-2:] == b"\r\n"
+        return (response_bytes.startswith(b"250") or b"\r\n250" in response_bytes) and response_bytes[-2:] == b"\r\n"
 
     def _get_response(self, command, response_class):
         self.sock.sendall(command)


### PR DESCRIPTION
Test if `250` is at the beginning of a line, should fix https://github.com/jams2/py-dict-client/issues/11
